### PR TITLE
Fix TODO

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,8 +4,12 @@ import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:pivot_chat/pages/login/login_page.dart';
 import 'package:pivot_chat/theme.dart';
 
+import 'package:pivot_chat/im.dart';
+
 class PCApp extends StatelessWidget {
   const PCApp({super.key});
+
+
 
   // This widget is the root of your application.
   @override
@@ -18,6 +22,8 @@ class PCApp extends StatelessWidget {
       scrollBehavior: const CupertinoScrollBehavior(),
       builder: FlutterSmartDialog.init(),
       onGenerateRoute: (RouteSettings setting) => LoginPage.route(),
+      //navigatorKey配置
+      navigatorKey:navigatorKey,
       debugShowCheckedModeBanner: false,
       // checkerboardOffscreenLayers: true,
       // checkerboardRasterCacheImages: true,

--- a/lib/im.dart
+++ b/lib/im.dart
@@ -13,6 +13,14 @@ import 'package:pivot_chat/manager/msg_publisher.dart';
 
 import 'manager/account_manager.dart';
 
+import 'package:pivot_chat/pages/login/login_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+
+//无context跳转的GlobalKey配置
+GlobalKey<NavigatorState> navigatorKey=GlobalKey();
+
+
 Future<void> initIM() async {
   if (kIsWeb) return;
   if (!Platform.isIOS && !Platform.isAndroid) {
@@ -49,13 +57,15 @@ Future<void> initIM() async {
       onUserTokenExpired: () {
         // 登录凭证已经过期，请重新登录。
         SmartDialog.showToast('IM登录凭证已经过期，请重新登录');
-        // TODO: pop to login page
+        // Done: pop to login page(无context跳转)
+        navigatorKey.currentState?.push(LoginPage.route());
       },
       onKickedOffline: () {
         // 当前用户被踢下线，此时可以 UI
         // 提示用户“您已经在其他端登录了当前账号，是否重新登录？”
         SmartDialog.showToast('IM当前用户被踢下线');
-        // TODO: pop to login page
+        // Done: pop to login page(无context跳转)
+        navigatorKey.currentState?.push(LoginPage.route());
       },
     ),
   ) as bool;


### PR DESCRIPTION
# feat(route):完成TODO项的页面跳转功能  
用户登录凭证过期或被踢下线时返回登录页，使用了GlobalKey进行无context跳转。